### PR TITLE
Fix problem with noarch packages

### DIFF
--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -106,17 +106,16 @@ def create_env(spec, force_recreation=False, extra_channels=()):
             index = get_index(extra_channels)
             # Ditto re the quietness.
             r = Resolve(index)
-            full_list_of_packages = r.solve(list(spec))
-
-            sorted_list_of_packages = r.dependency_sort({d.name: d for d in full_list_of_packages})
+            full_list_of_packages = sorted(r.solve(list(spec)))
 
             # Put out a newline. Conda's solve doesn't do it for us.
             log.info('\n')
 
             if CONDA_VERSION_MAJOR_MINOR >= (4, 3):
+                sorted_list_of_packages = r.dependency_sort({d.name: d for d in full_list_of_packages})
                 _create_env_conda_43(env_locn, index, sorted_list_of_packages)
             else:
-                _create_env_conda_42(env_locn, index, sorted_list_of_packages)
+                _create_env_conda_42(env_locn, index, full_list_of_packages)
 
             # Attach an execution.log file.
             with open(os.path.join(env_locn, 'conda-meta', 'execution.log'), 'a'):

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -106,15 +106,17 @@ def create_env(spec, force_recreation=False, extra_channels=()):
             index = get_index(extra_channels)
             # Ditto re the quietness.
             r = Resolve(index)
-            full_list_of_packages = sorted(r.solve(list(spec)))
+            full_list_of_packages = r.solve(list(spec))
+
+            sorted_list_of_packages = r.dependency_sort({d.name: d for d in full_list_of_packages})
 
             # Put out a newline. Conda's solve doesn't do it for us.
             log.info('\n')
 
             if CONDA_VERSION_MAJOR_MINOR >= (4, 3):
-                _create_env_conda_43(env_locn, index, full_list_of_packages)
+                _create_env_conda_43(env_locn, index, sorted_list_of_packages)
             else:
-                _create_env_conda_42(env_locn, index, full_list_of_packages)
+                _create_env_conda_42(env_locn, index, sorted_list_of_packages)
 
             # Attach an execution.log file.
             with open(os.path.join(env_locn, 'conda-meta', 'execution.log'), 'a'):


### PR DESCRIPTION
I noticed that when conda-execute was creating the environment, it was actioning the packages in alphabetical order. This meant that packages that required a [CompilePycAction](https://github.com/conda/conda/blob/master/conda/core/path_actions.py#L520) or [CreatePythonEntryPointAction](https://github.com/conda/conda/blob/master/conda/core/path_actions.py#L566) were failing as they needed something that wasn't there (e.g. python).

This sorts the packages using `dependency_sort `

Using conda-execute 0.8.1, trying to create an environment with funcsigs (a noarch package) in it, I was getting:
```
$ conda-execute -v delme.py
Arguments passed: Namespace(code=None, force_env=False, path='delme.py', quiet=False, remaining_args=[], verbose=True)
Using specification: 
channels: [conda-forge]
env: [python, numpy, funcsigs]
run_with: [/usr/bin/env, python]

Fetching package metadata ...


Solving package specifications: 




An error occurred while installing package 'conda-forge::funcsigs-1.0.2-py_2'.
FileNotFoundError(2, "No such file or directory: '/var/tmp/ldreyer/conda/tmp_envs/0e8e4bfc5ac4448f7033/bin/python3.6'")
Attempting to roll back.

Could not find execution log for /var/tmp/ldreyer/conda/tmp_envs/0e8e4bfc5ac4448f7033. Removing environment.
Traceback (most recent call last):
  File "/data/users/ldreyer/miniconda3/envs/_fix_conda_ex/lib/python3.6/site-packages/conda/core/link.py", line 326, in _execute_actions
    action.execute()
  File "/data/users/ldreyer/miniconda3/envs/_fix_conda_ex/lib/python3.6/site-packages/conda/core/path_actions.py", line 388, in execute
    compile_pyc(python_full_path, self.source_full_path, self.target_full_path)
  File "/data/users/ldreyer/miniconda3/envs/_fix_conda_ex/lib/python3.6/site-packages/conda
...
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/ldreyer/conda/tmp_envs/0e8e4bfc5ac4448f7033/bin/python3.6'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/users/ldreyer/miniconda3/envs/_fix_conda_ex/lib/python3.6/site-packages/conda/core/link.py", line 281, in execute
...
conda.CondaMultiError: [Errno 2] No such file or directory: '/var/tmp/ldreyer/conda/tmp_envs/0e8e4bfc5ac4448f7033/bin/python3.6'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/users/ldreyer/miniconda3/envs/_fix_conda_ex/bin/conda-execute", line 6, in <module>
    sys.exit(conda_execute.execute.main())
...
conda.CondaMultiError: [Errno 2] No such file or directory: '/var/tmp/ldreyer/conda/tmp_envs/0e8e4bfc5ac4448f7033/bin/python3.6'
```


But with this branch, I get:
```
$ conda-execute -v delme.py 
Arguments passed: Namespace(code=None, force_env=False, path='delme.py', quiet=False, remaining_args=[], verbose=True)
Using specification: 
channels: [conda-forge]
env: [python, numpy, funcsigs]
run_with: [/usr/bin/env, python]

Fetching package metadata ...


Solving package specifications: 




Prefix: /data/users/ldreyer/miniconda3/envs/_fix_conda_ex/tmp_envs/0e8e4bfc5ac4448f7033
Running command: ['/usr/bin/env', 'python', '/net/home/h03/ldreyer/delme.py']
[ 0.58464478  1.16712388  0.50764534]
````

No tests yet as I am having some trouble working out how is best to test this