### PR TITLE
CI: add the latest conda version 4.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - PYTHON_VERSION=2.7 CONDA_VERSION=4.5.3
   - PYTHON_VERSION=3.5 CONDA_VERSION=4.5.3
   - PYTHON_VERSION=3.6 CONDA_VERSION=4.5.3
+  - PYTHON_VERSION=3.6 CONDA_VERSION=4.6.2
 
 install:
   - export CONDA_BASE=http://repo.continuum.io/miniconda/Miniconda3


### PR DESCRIPTION
I observed an issue when running `conda-execute` with conda=4.6.2:
```py
======================================================================
ERROR: test_conda_execute_removes_envs_with_no_exe_log (tests.test_tmpenv.Test_tmpenv)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mrakitin/src/mrakitin/work/conda-execute/conda_execute/tests/test_tmpenv.py", line 24, in test_conda_execute_removes_envs_with_no_exe_log
    env_locn = conda_execute.tmpenv.create_env(env_spec)
  File "/Users/mrakitin/src/mrakitin/work/conda-execute/conda_execute/tmpenv.py", line 118, in create_env
    full_list_of_packages = sorted(r.solve(list(spec)))
TypeError: '<' not supported between instances of 'PackageRecord' and 'PackageRecord'
```
This PR is to reproduce the error on TravisCI, and the follow-up commits will fix the issue.